### PR TITLE
Fix method call site errors (Issue #10)

### DIFF
--- a/Sources/WinAmpPlayer/Core/Plugins/Examples/PluginIntegrationExample.swift
+++ b/Sources/WinAmpPlayer/Core/Plugins/Examples/PluginIntegrationExample.swift
@@ -15,7 +15,7 @@ public class VisualizationIntegrationExample {
     private var beatDetector: SimpleBeatDetector?
     
     // Visualization view
-    public let visualizationView = VisualizationView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+    public let visualizationView = PluginVisualizationView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
     
     // MARK: - Setup
     

--- a/Sources/WinAmpPlayer/UI/Views/ContentView.swift
+++ b/Sources/WinAmpPlayer/UI/Views/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
     ]
     @StateObject private var audioEngine = AudioEngine()
     @StateObject private var volumeController: VolumeBalanceController
+    @StateObject private var playlistController: PlaylistController
     @StateObject private var playlist = Playlist(name: "Main Playlist")
     
     @State private var isDraggingSeekBar = false
@@ -35,10 +36,12 @@ struct ContentView: View {
     
     init() {
         let engine = AudioEngine()
-        let controller = VolumeBalanceController(audioEngine: engine.audioEngine)
-        engine.setVolumeController(controller)
+        let volumeCtrl = VolumeBalanceController(audioEngine: engine.audioEngine)
+        let playlistCtrl = PlaylistController(audioEngine: engine, volumeController: volumeCtrl)
+        engine.setVolumeController(volumeCtrl)
         _audioEngine = StateObject(wrappedValue: engine)
-        _volumeController = StateObject(wrappedValue: controller)
+        _volumeController = StateObject(wrappedValue: volumeCtrl)
+        _playlistController = StateObject(wrappedValue: playlistCtrl)
     }
     
     var body: some View {
@@ -524,7 +527,7 @@ struct PlaylistWindowView: View {
             PlaylistControlsView(playlist: playlist)
                 .frame(height: 26)
             
-            PlaylistView(playlist: playlist)
+            PlaylistView(controller: playlistController, playlist: playlist)
                 .frame(minWidth: 550, minHeight: 300)
         }
         .background(Color(red: 0.11, green: 0.11, blue: 0.11))

--- a/Sources/WinAmpPlayer/UI/Views/MainPlayerView.swift
+++ b/Sources/WinAmpPlayer/UI/Views/MainPlayerView.swift
@@ -318,9 +318,9 @@ struct WinAmpSlider: View {
     }
 }
 
-// MARK: - Window Control Button
+// MARK: - Clutterbar Button
 
-struct WindowControlButton: View {
+struct ClutterbarButton: View {
     let icon: String
     let action: () -> Void
     @State private var isHovered = false
@@ -444,13 +444,13 @@ public struct MainPlayerView: View {
                     
                     // Clutterbar
                     HStack(spacing: 2) {
-                        WindowControlButton(icon: "option") {
+                        ClutterbarButton(icon: "option") {
                             // Options menu
                         }
-                        WindowControlButton(icon: "filemenu.and.selection") {
+                        ClutterbarButton(icon: "filemenu.and.selection") {
                             // File menu
                         }
-                        WindowControlButton(icon: "waveform") {
+                        ClutterbarButton(icon: "waveform") {
                             isVisualizationVisible.toggle()
                         }
                     }
@@ -545,10 +545,10 @@ public struct MainPlayerView: View {
                     
                     // Window buttons
                     HStack(spacing: 2) {
-                        WindowControlButton(icon: "waveform.badge.plus") {
+                        ClutterbarButton(icon: "waveform.badge.plus") {
                             WindowManager.shared.toggleWindow(.equalizer)
                         }
-                        WindowControlButton(icon: "list.bullet") {
+                        ClutterbarButton(icon: "list.bullet") {
                             WindowManager.shared.toggleWindow(.playlist)
                         }
                     }

--- a/Sources/WinAmpPlayer/UI/Windows/WinAmpWindow.swift
+++ b/Sources/WinAmpPlayer/UI/Windows/WinAmpWindow.swift
@@ -110,20 +110,16 @@ struct WinAmpTitleBar: View {
         HStack(spacing: 4) {
             // Window controls
             HStack(spacing: 2) {
-                WindowControlButton(icon: "xmark") {
-                    onClose()
-                }
+                WindowControlButton(type: .close, action: onClose)
                 
-                WindowControlButton(icon: "minus") {
-                    onMinimize()
-                }
+                WindowControlButton(type: .minimize, action: onMinimize)
                 
-                WindowControlButton(icon: "arrow.up.arrow.down") {
+                WindowControlButton(type: .shade, action: {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                         isShaded.toggle()
                         WindowManager.shared.setShadeMode(isShaded, for: windowType)
                     }
-                }
+                })
             }
             .padding(.leading, 6)
             

--- a/winamp_state.md
+++ b/winamp_state.md
@@ -27,11 +27,18 @@ This file tracks the development progress, sprint status, and overall project st
 - Fixed protocol conformance issues
 - Documented remaining minor issues for incremental fixes
 
-### PR #13 Merged ✅ (2025-07-19)
-- **Issue #8 Resolved**: Fixed type ambiguity errors
+### PR #8 Merged ✅ (2025-07-19)
+- **Issue #13 Resolved**: Fixed type ambiguity errors
 - Updated SmartPlaylistRule to use SmartPlaylistComparisonOperator consistently
 - Resolved VisualizationView naming conflict (renamed to PluginVisualizationView)
 - Reduced compilation errors from 841 to 767
+
+### PR #9 Merged ✅ (2025-07-19)
+- **Issue #14 Resolved**: Fixed method visibility errors
+- Made AudioEngine playerNode and audioFile internal for extension access
+- Made WindowManager checkForSnapping internal for delegate access
+- Restructured MetadataCache Statistics for public API access
+- Reduced compilation errors from 767 to 673
 - **Major Achievement**: Removed all iOS-specific audio APIs
 - Created `macOSAudioDeviceManager.swift` with CoreAudio integration
 - Created `macOSAudioSystemManager.swift` replacing AVAudioSession


### PR DESCRIPTION
## Summary
- Fixed incorrect argument labels and missing parameters in method calls
- Resolved naming conflicts between UI components
- Reduced compilation errors from 673 to 525

## Changes
### ContentView Updates
- Added PlaylistController initialization
- Fixed PlaylistView call to include both controller and playlist parameters

### Plugin System Fixes
- Fixed PluginIntegrationExample to use PluginVisualizationView (NSView-based) instead of UI VisualizationView (SwiftUI)

### Window Control Fixes
- Updated WinAmpWindow WindowControlButton calls to use type parameter instead of icon
- Renamed MainPlayerView's WindowControlButton to ClutterbarButton to avoid conflict with WinAmpWindow's definition

## Impact
This PR resolves method call site errors that were preventing compilation. The fixes ensure that:
- All required parameters are provided to initializers
- Correct argument labels are used
- Type conflicts between similarly named components are resolved

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)